### PR TITLE
Fix image flicker issue

### DIFF
--- a/public_html/js/background.cycle.js
+++ b/public_html/js/background.cycle.js
@@ -138,11 +138,6 @@ function cycleToNextImage() {
         currentImageIndex = 0;
     }
 
-    var options = {
-        duration: fadeSpeed,
-        queue: false
-    };
-
-    $('#' + previousImageId).fadeOut(options);
-    $('#' + imageIds[currentImageIndex]).fadeIn(options);
+    $('#' + previousImageId).fadeTo(fadeSpeed, 0);
+    $('#' + imageIds[currentImageIndex]).fadeTo(fadeSpeed, 1);
 }


### PR DESCRIPTION
On some browsers, background images would sometimes appear to flash with full opacity before fading in.

This may have been to do with the behaviour of the `fadeOut` and `fadeIn` functions, so these have been replaced with `fadeTo`.